### PR TITLE
add support of python 3.10 & python 3.11 in continuous integration

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -9,7 +9,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: [3.9]
+            python-version: ["3.10"]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -9,7 +9,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: [3.9]
+            python-version: ["3.10"]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: [3.7, 3.8, 3.9]
+            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: [3.9]
+            python-version: ["3.10"]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -9,7 +9,7 @@ jobs:
 
         strategy:
           matrix:
-            python-version: [3.9]
+            python-version: ["3.10"]
             examples: ['kanban_flask_sqlite', 'unittest', 'kanban_flask_postgresql']
 
         steps:


### PR DESCRIPTION
We use python version 3.10 as standard.